### PR TITLE
[FEAT] 랜딩페이지 항공권 호출 API

### DIFF
--- a/src/main/java/sopt35/skyscanner/controller/CardController.java
+++ b/src/main/java/sopt35/skyscanner/controller/CardController.java
@@ -1,6 +1,5 @@
 package sopt35.skyscanner.controller;
 
-import java.util.ArrayList;
 import java.util.List;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -8,8 +7,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import sopt35.skyscanner.dto.CardListResponse;
 import sopt35.skyscanner.dto.CardResponse;
-import sopt35.skyscanner.repository.Flight;
-import sopt35.skyscanner.service.FlightService;
+import sopt35.skyscanner.service.CardService;
 
 @RestController
 @RequestMapping("/card")
@@ -17,14 +15,12 @@ public class CardController {
 
     private final CardService cardService;
 
-
     public CardController(CardService cardService) {
         this.cardService = cardService;
     }
 
     @GetMapping("/")
     public ResponseEntity<CardListResponse> get() {
-
         List<CardResponse> cardResponseList = cardService.getAllCards();
         return ResponseEntity.ok(new CardListResponse(cardResponseList));
     }

--- a/src/main/java/sopt35/skyscanner/controller/CardController.java
+++ b/src/main/java/sopt35/skyscanner/controller/CardController.java
@@ -1,0 +1,31 @@
+package sopt35.skyscanner.controller;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import sopt35.skyscanner.dto.CardListResponse;
+import sopt35.skyscanner.dto.CardResponse;
+import sopt35.skyscanner.repository.Flight;
+import sopt35.skyscanner.service.FlightService;
+
+@RestController
+@RequestMapping("/card")
+public class CardController {
+
+    private final CardService cardService;
+
+
+    public CardController(CardService cardService) {
+        this.cardService = cardService;
+    }
+
+    @GetMapping("/")
+    public ResponseEntity<CardListResponse> get() {
+
+        List<CardResponse> cardResponseList = cardService.getAllCards();
+        return ResponseEntity.ok(new CardListResponse(cardResponseList));
+    }
+}

--- a/src/main/java/sopt35/skyscanner/controller/TestController.java
+++ b/src/main/java/sopt35/skyscanner/controller/TestController.java
@@ -10,7 +10,7 @@ public class TestController {
 
     @GetMapping("/")
     public String test() {
-        return "I'M HEALTHY!";
+        return "I'M HEALTHY!!";
     }
 
 }

--- a/src/main/java/sopt35/skyscanner/dto/CardListResponse.java
+++ b/src/main/java/sopt35/skyscanner/dto/CardListResponse.java
@@ -1,0 +1,17 @@
+package sopt35.skyscanner.dto;
+
+import java.util.List;
+
+public class CardListResponse {
+    private final List<CardResponse> cardResponseList;
+
+    // 생성자: List<Card>를 받아서 CardResponse 객체 리스트로 변환
+    public CardListResponse(List<CardResponse> cardResponseList) {
+        this.cardResponseList = cardResponseList;
+    }
+
+    // Getter and Setter
+    public List<CardResponse> getCardResponseList() {
+        return cardResponseList;
+    }
+}

--- a/src/main/java/sopt35/skyscanner/dto/CardResponse.java
+++ b/src/main/java/sopt35/skyscanner/dto/CardResponse.java
@@ -1,0 +1,112 @@
+package sopt35.skyscanner.dto;
+
+import sopt35.skyscanner.repository.Card;
+
+public class CardResponse {
+    private long id;
+    private String country;
+    private String spot;
+    private String price;
+    private String departureAirlineImageUrl;
+    private String departureDate;
+    private String departureTicketDescription;
+    private String arrivalAirlineImageUrl;
+    private String arrivalDate;
+    private String arrivalTicketDescription;
+
+    // Card 객체를 받아서 초기화하는 생성자
+    public CardResponse(Card card) {
+        this.id = card.getId();
+        this.country = card.getCountry();
+        this.spot = card.getSpot();
+        this.price = card.getPrice();
+        this.departureAirlineImageUrl = card.getDepartureAirlineImageUrl();
+        this.departureDate = card.getDepartureDate();
+        this.departureTicketDescription = card.getDepartureTicketDescription();
+        this.arrivalAirlineImageUrl = card.getArrivalAirlineImageUrl();
+        this.arrivalDate = card.getArrivalDate();
+        this.arrivalTicketDescription = card.getArrivalTicketDescription();
+    }
+
+    // Getters and Setters
+    public long getId() {
+        return id;
+    }
+
+    public void setId(long id) {
+        this.id = id;
+    }
+
+    public String getCountry() {
+        return country;
+    }
+
+    public void setCountry(String country) {
+        this.country = country;
+    }
+
+    public String getSpot() {
+        return spot;
+    }
+
+    public void setSpot(String spot) {
+        this.spot = spot;
+    }
+
+    public String getPrice() {
+        return price;
+    }
+
+    public void setPrice(String price) {
+        this.price = price;
+    }
+
+    public String getDepartureAirlineImageUrl() {
+        return departureAirlineImageUrl;
+    }
+
+    public void setDepartureAirlineImageUrl(String departureAirlineImageUrl) {
+        this.departureAirlineImageUrl = departureAirlineImageUrl;
+    }
+
+    public String getDepartureDate() {
+        return departureDate;
+    }
+
+    public void setDepartureDate(String departureDate) {
+        this.departureDate = departureDate;
+    }
+
+    public String getDepartureTicketDescription() {
+        return departureTicketDescription;
+    }
+
+    public void setDepartureTicketDescription(String departureTicketDescription) {
+        this.departureTicketDescription = departureTicketDescription;
+    }
+
+    public String getArrivalAirlineImageUrl() {
+        return arrivalAirlineImageUrl;
+    }
+
+    public void setArrivalAirlineImageUrl(String arrivalAirlineImageUrl) {
+        this.arrivalAirlineImageUrl = arrivalAirlineImageUrl;
+    }
+
+    public String getArrivalDate() {
+        return arrivalDate;
+    }
+
+    public void setArrivalDate(String arrivalDate) {
+        this.arrivalDate = arrivalDate;
+    }
+
+    public String getArrivalTicketDescription() {
+        return arrivalTicketDescription;
+    }
+
+    public void setArrivalTicketDescription(String arrivalTicketDescription) {
+        this.arrivalTicketDescription = arrivalTicketDescription;
+    }
+
+}

--- a/src/main/java/sopt35/skyscanner/dto/CardResponse.java
+++ b/src/main/java/sopt35/skyscanner/dto/CardResponse.java
@@ -2,6 +2,7 @@ package sopt35.skyscanner.dto;
 
 import sopt35.skyscanner.repository.Card;
 
+
 public class CardResponse {
     private long id;
     private String country;
@@ -28,7 +29,7 @@ public class CardResponse {
         this.arrivalTicketDescription = card.getArrivalTicketDescription();
     }
 
-    // Getters and Setters
+    // Getter와 Setter
     public long getId() {
         return id;
     }
@@ -108,5 +109,4 @@ public class CardResponse {
     public void setArrivalTicketDescription(String arrivalTicketDescription) {
         this.arrivalTicketDescription = arrivalTicketDescription;
     }
-
 }

--- a/src/main/java/sopt35/skyscanner/repository/Card.java
+++ b/src/main/java/sopt35/skyscanner/repository/Card.java
@@ -1,0 +1,124 @@
+package sopt35.skyscanner.repository;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import java.time.LocalDate;
+
+@Entity
+public class Card {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String country;
+    private String spot;
+
+    private String price;
+
+    // 출발 항공사 이미지 URL
+    private String departureAirlineImageUrl;
+
+    // 출발 날짜
+    private String departureDate;
+
+    // 출발 항공권 설명
+    private String departureTicketDescription;
+
+    // 도착 항공사 이미지 URL
+    private String arrivalAirlineImageUrl;
+
+    // 도착 날짜
+    private String arrivalDate;
+
+    // 도착 항공권 설명
+    private String arrivalTicketDescription;
+
+    // 기본 생성자
+    public Card() {
+    }
+
+    // 게터/세터 메서드
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getCountry() {
+        return country;
+    }
+
+    public void setCountry(String country) {
+        this.country = country;
+    }
+
+    public String getSpot() {
+        return spot;
+    }
+
+    public void setSpot(String spot) {
+        this.spot = spot;
+    }
+
+    public String getPrice() {
+        return price;
+    }
+
+    public void setPrice(String price) {
+        this.price = price;
+    }
+
+    public String getDepartureAirlineImageUrl() {
+        return departureAirlineImageUrl;
+    }
+
+    public void setDepartureAirlineImageUrl(String departureAirlineImageUrl) {
+        this.departureAirlineImageUrl = departureAirlineImageUrl;
+    }
+
+    public String getDepartureDate() {
+        return departureDate;
+    }
+
+    public void setDepartureDate(String departureDate) {
+        this.departureDate = departureDate;
+    }
+
+    public String getDepartureTicketDescription() {
+        return departureTicketDescription;
+    }
+
+    public void setDepartureTicketDescription(String departureTicketDescription) {
+        this.departureTicketDescription = departureTicketDescription;
+    }
+
+    public String getArrivalAirlineImageUrl() {
+        return arrivalAirlineImageUrl;
+    }
+
+    public void setArrivalAirlineImageUrl(String arrivalAirlineImageUrl) {
+        this.arrivalAirlineImageUrl = arrivalAirlineImageUrl;
+    }
+
+    public String getArrivalDate() {
+        return arrivalDate;
+    }
+
+    public void setArrivalDate(String arrivalDate) {
+        this.arrivalDate = arrivalDate;
+    }
+
+    public String getArrivalTicketDescription() {
+        return arrivalTicketDescription;
+    }
+
+    public void setArrivalTicketDescription(String arrivalTicketDescription) {
+        this.arrivalTicketDescription = arrivalTicketDescription;
+    }
+}

--- a/src/main/java/sopt35/skyscanner/repository/Card.java
+++ b/src/main/java/sopt35/skyscanner/repository/Card.java
@@ -4,7 +4,6 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
-import java.time.LocalDate;
 
 @Entity
 public class Card {
@@ -12,6 +11,8 @@ public class Card {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
+
+    private String backgroundImageUrl;
 
     private String country;
     private String spot;
@@ -40,85 +41,49 @@ public class Card {
     public Card() {
     }
 
-    // 게터/세터 메서드
+    // Getter 메서드
 
     public Long getId() {
         return id;
     }
 
-    public void setId(Long id) {
-        this.id = id;
+    public String getBackgroundImageUrl() {
+        return backgroundImageUrl;
     }
 
     public String getCountry() {
         return country;
     }
 
-    public void setCountry(String country) {
-        this.country = country;
-    }
-
     public String getSpot() {
         return spot;
-    }
-
-    public void setSpot(String spot) {
-        this.spot = spot;
     }
 
     public String getPrice() {
         return price;
     }
 
-    public void setPrice(String price) {
-        this.price = price;
-    }
-
     public String getDepartureAirlineImageUrl() {
         return departureAirlineImageUrl;
-    }
-
-    public void setDepartureAirlineImageUrl(String departureAirlineImageUrl) {
-        this.departureAirlineImageUrl = departureAirlineImageUrl;
     }
 
     public String getDepartureDate() {
         return departureDate;
     }
 
-    public void setDepartureDate(String departureDate) {
-        this.departureDate = departureDate;
-    }
-
     public String getDepartureTicketDescription() {
         return departureTicketDescription;
-    }
-
-    public void setDepartureTicketDescription(String departureTicketDescription) {
-        this.departureTicketDescription = departureTicketDescription;
     }
 
     public String getArrivalAirlineImageUrl() {
         return arrivalAirlineImageUrl;
     }
 
-    public void setArrivalAirlineImageUrl(String arrivalAirlineImageUrl) {
-        this.arrivalAirlineImageUrl = arrivalAirlineImageUrl;
-    }
-
     public String getArrivalDate() {
         return arrivalDate;
     }
 
-    public void setArrivalDate(String arrivalDate) {
-        this.arrivalDate = arrivalDate;
-    }
-
     public String getArrivalTicketDescription() {
         return arrivalTicketDescription;
-    }
-
-    public void setArrivalTicketDescription(String arrivalTicketDescription) {
-        this.arrivalTicketDescription = arrivalTicketDescription;
     }
 }

--- a/src/main/java/sopt35/skyscanner/repository/CardRepository.java
+++ b/src/main/java/sopt35/skyscanner/repository/CardRepository.java
@@ -1,0 +1,8 @@
+package sopt35.skyscanner.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface CardRepository extends JpaRepository<Card, Long> {
+}

--- a/src/main/java/sopt35/skyscanner/service/CardService.java
+++ b/src/main/java/sopt35/skyscanner/service/CardService.java
@@ -1,0 +1,25 @@
+package sopt35.skyscanner.service;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.springframework.stereotype.Component;
+import sopt35.skyscanner.dto.CardResponse;
+import sopt35.skyscanner.repository.Card;
+import sopt35.skyscanner.repository.CardRepository;
+
+@Component
+public class CardService {
+    private final CardRepository cardRepository;
+
+    public CardService(CardRepository cardRepository) {
+        this.cardRepository = cardRepository;
+    }
+    public List<CardResponse> getAllCards() {
+        final List<Card> cardList = cardRepository.findAll();
+        final List<CardResponse> cardResponseList = new ArrayList<>();
+        for (Card card: cardList) {
+            cardResponseList.add(new CardResponse(card));
+        }
+        return cardResponseList;
+    }
+}


### PR DESCRIPTION
## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #28 

## 📝 Summary
<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
랜딩페이지 항공권 3개 호출 API를 개발했습니다.
카드 정보를 card 테이블에 저장했고 /card/ 호출시 전부 불러옵니다.
 [CardResponse](https://github.com/hyukjinKimm/skyscanner-sopt35/commit/744801ec3c174753eb8c42de5648df5955107eb8#diff-270beac41bee3d3cf789095cdd9fe67370eb0126d98a126a1447a88814c8e5f9R18)를  [CardListResponse](https://github.com/hyukjinKimm/skyscanner-sopt35/commit/744801ec3c174753eb8c42de5648df5955107eb8#diff-a333e5c591ae9f9dadedafe0e90d881fecb9fcf132f243a6070690477b29701eR5)로 감싸 응답합니다.


## 🙏 Question & PR point
<!-- PR과정에서 다른 팀원이 알아야할 사항이나 궁금증을 적어주세요 -->
card 테이블에 3row 를 집어넣었습니다.
![image](https://github.com/user-attachments/assets/097e10e0-83b7-4aa8-84a1-358f451c1744)
