### PR TITLE
Feat/#31

### DIFF
--- a/src/main/java/sopt35/skyscanner/controller/CalendarController.java
+++ b/src/main/java/sopt35/skyscanner/controller/CalendarController.java
@@ -10,7 +10,6 @@ import sopt35.skyscanner.service.CalendarService;
 import java.util.List;
 
 @RestController
-@RequestMapping("calendar")
 public class CalendarController {
 
     private final CalendarService calendarService;
@@ -20,7 +19,7 @@ public class CalendarController {
     }
 
     // 월별 항공편 가격 반환 API
-    @GetMapping("/")
+    @GetMapping("/calendar")
     public ResponseEntity<List<PriceListResponse>> getPriceByMonth() {
 
         List<PriceListResponse> prices = calendarService.getPriceGroupByMonth();

--- a/src/main/java/sopt35/skyscanner/controller/CalendarController.java
+++ b/src/main/java/sopt35/skyscanner/controller/CalendarController.java
@@ -1,0 +1,31 @@
+package sopt35.skyscanner.controller;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import sopt35.skyscanner.dto.PriceListResponse;
+import sopt35.skyscanner.service.CalendarService;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("calendar")
+public class CalendarController {
+
+    private final CalendarService calendarService;
+
+    public CalendarController(CalendarService calendarService){
+        this.calendarService = calendarService;
+    }
+
+    // 월별 항공편 가격 반환 API
+    @GetMapping("/")
+    public ResponseEntity<List<PriceListResponse>> getPriceByMonth() {
+
+        List<PriceListResponse> prices = calendarService.getPriceGroupByMonth();
+        return ResponseEntity.ok(prices);
+
+    }
+
+}

--- a/src/main/java/sopt35/skyscanner/controller/FlightController.java
+++ b/src/main/java/sopt35/skyscanner/controller/FlightController.java
@@ -1,8 +1,12 @@
 package sopt35.skyscanner.controller;
 
 import java.util.List;
+
+import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.*;
+import sopt35.skyscanner.dto.FlightAggregateResponse;
+import sopt35.skyscanner.dto.PriceListResponse;
 import sopt35.skyscanner.dto.WishListResponse;
 import sopt35.skyscanner.repository.Flight;
 import sopt35.skyscanner.service.FlightService;
@@ -26,4 +30,13 @@ public class FlightController {
     public void patchWishList(@RequestParam Long flightId) {
         flightService.updateWishList(flightId);
     }
+
+
+    @GetMapping("flights")
+    public ResponseEntity<FlightAggregateResponse> getFlight() {
+        FlightAggregateResponse response = flightService.getTopFlightsAndAveragePrice();
+        return ResponseEntity.ok(response);
+    }
+
+
 }

--- a/src/main/java/sopt35/skyscanner/dto/FlightAggregateResponse.java
+++ b/src/main/java/sopt35/skyscanner/dto/FlightAggregateResponse.java
@@ -1,0 +1,32 @@
+package sopt35.skyscanner.dto;
+
+import java.util.List;
+
+public class FlightAggregateResponse {
+    private List<FlightResponse> flights;
+    private float averageTotalPrice;
+
+    public FlightAggregateResponse(List<FlightResponse> flights, float averageTotalPrice) {
+        this.flights = flights;
+        this.averageTotalPrice = averageTotalPrice;
+    }
+
+    // Getter and Setter
+
+    public List<FlightResponse> getFlights() {
+        return flights;
+    }
+
+    public float getAverageTotalPrice() {
+        return averageTotalPrice;
+    }
+
+    public void setFlights(List<FlightResponse> flights) {
+        this.flights = flights;
+    }
+
+    public void setAverageTotalPrice(float averageTotalPrice) {
+        this.averageTotalPrice = averageTotalPrice;
+    }
+}
+

--- a/src/main/java/sopt35/skyscanner/dto/FlightResponse.java
+++ b/src/main/java/sopt35/skyscanner/dto/FlightResponse.java
@@ -1,0 +1,132 @@
+package sopt35.skyscanner.dto;
+
+public class FlightResponse {
+
+    private Long id;
+    private String airline;
+    private String airlineUrl;
+    private String departAt;
+    private String arriveAt;
+    private String depFlightTimeline;
+    private String depFlightTime;
+    private String depAirport;
+    private String arrFlightTimeline;
+    private String arrFlightTime;
+    private String arrAirport;
+    private float totalPrice; // arrPrice + depPrice
+
+
+    public FlightResponse(Long id, String airline, String airlineUrl, String departAt, String arriveAt,
+                          String depFlightTimeline, String depFlightTime, String depAirport,
+                          String arrFlightTimeline, String arrFlightTime, String arrAirport, float totalPrice) {
+        this.id = id;
+        this.airline = airline;
+        this.airlineUrl = airlineUrl;
+        this.departAt = departAt;
+        this.arriveAt = arriveAt;
+        this.depFlightTimeline = depFlightTimeline;
+        this.depFlightTime = depFlightTime;
+        this.depAirport = depAirport;
+        this.arrFlightTimeline = arrFlightTimeline;
+        this.arrFlightTime = arrFlightTime;
+        this.arrAirport = arrAirport;
+        this.totalPrice = totalPrice;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getAirline() {
+        return airline;
+    }
+
+    public void setAirline(String airline) {
+        this.airline = airline;
+    }
+
+    public String getAirlineUrl() {
+        return airlineUrl;
+    }
+
+    public void setAirlineUrl(String airlineUrl) {
+        this.airlineUrl = airlineUrl;
+    }
+
+    public String getDepartAt() {
+        return departAt;
+    }
+
+    public void setDepartAt(String departAt) {
+        this.departAt = departAt;
+    }
+
+    public String getArriveAt() {
+        return arriveAt;
+    }
+
+    public void setArriveAt(String arriveAt) {
+        this.arriveAt = arriveAt;
+    }
+
+    public String getDepFlightTimeline() {
+        return depFlightTimeline;
+    }
+
+    public void setDepFlightTimeline(String depFlightTimeline) {
+        this.depFlightTimeline = depFlightTimeline;
+    }
+
+    public String getDepFlightTime() {
+        return depFlightTime;
+    }
+
+    public void setDepFlightTime(String depFlightTime) {
+        this.depFlightTime = depFlightTime;
+    }
+
+    public String getDepAirport() {
+        return depAirport;
+    }
+
+    public void setDepAirport(String depAirport) {
+        this.depAirport = depAirport;
+    }
+
+    public String getArrFlightTimeline() {
+        return arrFlightTimeline;
+    }
+
+    public void setArrFlightTimeline(String arrFlightTimeline) {
+        this.arrFlightTimeline = arrFlightTimeline;
+    }
+
+    public String getArrFlightTime() {
+        return arrFlightTime;
+    }
+
+    public void setArrFlightTime(String arrFlightTime) {
+        this.arrFlightTime = arrFlightTime;
+    }
+
+    public String getArrAirport() {
+        return arrAirport;
+    }
+
+    public void setArrAirport(String arrAirport) {
+        this.arrAirport = arrAirport;
+    }
+
+    public float getTotalPrice() {
+        return totalPrice;
+    }
+
+    public void setTotalPrice(float totalPrice) {
+        this.totalPrice = totalPrice;
+    }
+}
+

--- a/src/main/java/sopt35/skyscanner/dto/PriceListResponse.java
+++ b/src/main/java/sopt35/skyscanner/dto/PriceListResponse.java
@@ -1,0 +1,30 @@
+package sopt35.skyscanner.dto;
+
+import java.util.List;
+
+public class PriceListResponse {
+
+    private String month; // 예: "2024-11"
+    private List<PriceResponse> prices;
+
+    public PriceListResponse(String month, List<PriceResponse> prices) {
+        this.month = month;
+        this.prices = prices;
+    }
+
+    public List<PriceResponse> getPrices() {
+        return prices;
+    }
+
+    public String getMonth() {
+        return month;
+    }
+
+    public void setPrices(List<PriceResponse> prices) {
+        this.prices = prices;
+    }
+
+    public void setMonth(String month) {
+        this.month = month;
+    }
+}

--- a/src/main/java/sopt35/skyscanner/dto/PriceResponse.java
+++ b/src/main/java/sopt35/skyscanner/dto/PriceResponse.java
@@ -1,0 +1,40 @@
+package sopt35.skyscanner.dto;
+
+import java.time.LocalDate;
+
+public class PriceResponse {
+
+    private long id;
+    private LocalDate date;
+    private Float price;
+
+    public PriceResponse(long id, LocalDate date, Float price) {
+        this.id = id;
+        this.date = date;
+        this.price = price;
+    }
+
+    public long getId() {
+        return id;
+    }
+
+    public Float getPrice() {
+        return price;
+    }
+
+    public LocalDate getDate() {
+        return date;
+    }
+
+    public void setId(long id) {
+        this.id = id;
+    }
+
+    public void setPrice(Float price) {
+        this.price = price;
+    }
+
+    public void setDate(LocalDate date) {
+        this.date = date;
+    }
+}

--- a/src/main/java/sopt35/skyscanner/repository/FlightRepository.java
+++ b/src/main/java/sopt35/skyscanner/repository/FlightRepository.java
@@ -1,6 +1,7 @@
 package sopt35.skyscanner.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -8,4 +9,12 @@ import java.util.List;
 @Repository
 public interface FlightRepository extends JpaRepository<Flight, Long> {
     List<Flight> findAllByIsLikeTrue();
+
+    // 가격 합 기준으로 상위 5개 항공편 조회
+    List<Flight> findTop5ByOrderByArrPriceAsc();
+
+    // 전체 가격 합 평균 계산
+    @Query("SELECT AVG(f.arrPrice + f.depPrice) FROM Flight f")
+    float findAveragePriceSum();
+
 }

--- a/src/main/java/sopt35/skyscanner/repository/Price.java
+++ b/src/main/java/sopt35/skyscanner/repository/Price.java
@@ -5,7 +5,8 @@ import static jakarta.persistence.GenerationType.IDENTITY;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
-import java.time.LocalDateTime;
+
+import java.time.LocalDate;
 
 @Entity
 public class Price {
@@ -14,8 +15,35 @@ public class Price {
     @GeneratedValue(strategy = IDENTITY)
     private Long id;
 
-    private LocalDateTime date;
+    private LocalDate date;
 
-    private int price;
+    private float price;
 
+    public Price(){
+
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public float getPrice() {
+        return price;
+    }
+
+    public LocalDate getDate() {
+        return date;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public void setPrice(float price) {
+        this.price = price;
+    }
+
+    public void setDate(LocalDate date) {
+        this.date = date;
+    }
 }

--- a/src/main/java/sopt35/skyscanner/repository/PriceRepository.java
+++ b/src/main/java/sopt35/skyscanner/repository/PriceRepository.java
@@ -1,0 +1,9 @@
+package sopt35.skyscanner.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+
+@Repository
+public interface PriceRepository extends JpaRepository<Price, Long> {
+}

--- a/src/main/java/sopt35/skyscanner/service/CalendarService.java
+++ b/src/main/java/sopt35/skyscanner/service/CalendarService.java
@@ -1,0 +1,38 @@
+package sopt35.skyscanner.service;
+
+import org.springframework.stereotype.Service;
+import sopt35.skyscanner.dto.PriceListResponse;
+import sopt35.skyscanner.dto.PriceResponse;
+import sopt35.skyscanner.repository.Price;
+import sopt35.skyscanner.repository.PriceRepository;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Service
+public class CalendarService {
+
+    PriceRepository priceRepository;
+
+    public CalendarService(PriceRepository priceRepository){
+        this.priceRepository = priceRepository;
+    }
+
+    public List<PriceListResponse> getPriceGroupByMonth(){
+
+        List<Price> prices = priceRepository.findAll(); // DB의 모든 Price 데이터 가져옴
+
+        // Stream API로 Price를 월별로 그룹화함
+        Map<String, List<PriceResponse>> groupedByMonth = prices.stream()
+                .map(price -> new PriceResponse(price.getId(), price.getDate(), price.getPrice())) // DTO 변환
+                .collect(Collectors.groupingBy(
+                        price -> price.getDate().getYear() + "-" + price.getDate().getMonthValue() // YYYY-MM 형태로 월 구분
+                ));
+
+        // 그룹화된 데이터를 PriceListResponse로 변환함
+        return groupedByMonth.entrySet().stream()
+                .map(entry -> new PriceListResponse(entry.getKey(), entry.getValue()))
+                .collect(Collectors.toList());
+    }
+}


### PR DESCRIPTION
## 📣 Related Issue
항공편 조회 시, 프론트 쪽에서 특정 날짜를 지정해서 요청하는지 확인이 필요합니다. 현재는 날짜 정보를 사용하지 않고 최저가만을 기준으로  처리하였습니다. 
또한 마찬가지로 인원수 정보가 요청에 포함되는지 확인이 필요합니다. 현재는 1인당 가격으로 반환하도록 처리해두었습니다. 

## 📝 Summary
캘린더 호출 API와 항공편 조회 API를 구현하였습니다. 
캘린더 호출의 경우 Price 테이블의 모든 데이터를 반환하고, 항공편 조회 API는 임시로 최저가 기준 5개의 항공편을 반환하는 것으로 구현해두었습니다. 

## 🙏 Question & PR point

