### PR TITLE
[FIX] 프론트 도메인의 요청 허용

### DIFF
--- a/src/main/java/sopt35/skyscanner/config/WebConfig.java
+++ b/src/main/java/sopt35/skyscanner/config/WebConfig.java
@@ -13,7 +13,7 @@ public class WebConfig implements WebMvcConfigurer {
     public void addCorsMappings(CorsRegistry registry) {
         // 특정 도메인에서만 CORS 요청을 허용
         registry.addMapping("/**")
-                .allowedOrigins("http://localhost:5173") // 허용할 출처 : 특정 도메인만 받을 수 있음
+                .allowedOrigins("http://localhost:5173", "https://35-collaboration-web-skyscanner-6mls.vercel.app") // 허용할 출처 : 특정 도메인만 받을 수 있음
                 .allowedMethods("GET", "POST", "PATCH") // 허용할 HTTP method
                 .allowedHeaders("Content-Type", "Authorization", "X-Requested-With") // 클라이언트가 보낼 수 있는 헤더들
                 .exposedHeaders("Authorization") // 클라이언트가 응답 헤더에서 읽을 수 있는 헤더들


### PR DESCRIPTION
## 📣 Related Issue


## 📝 Summary
프론트 배포 도메인으로부터의 CORS 요청을 허용하도록 WebConfig.java 파일 수정하였습니다


## 🙏 Question & PR point
1. 프론트 배포 도메인은 https://35-collaboration-web-skyscanner-6mls.vercel.app/입니다. 이것만 CORS 허용 domain에 추가한 상태인데 이걸로 충분한건지 확인 부탁드립니다!!
2. 서버 상의 yaml 파일에서도 수정이 필요한지 명확히 잘 모르겠습니다...